### PR TITLE
Update SwiftAutoGUI and migrate to Action API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can operate the mouse according to your hand movements as follows.
 [SwiftAutoGUI](https://github.com/NakaokaRei/SwiftAutoGUI) is used for mouse operation.
 
 > **Warning**
-> This app only works on Apple Silicon.
+> This app requires macOS 26 or later and Apple Silicon.
 
 <img src="img/demo.gif" width="700">
 

--- a/TrackpadAir.xcodeproj/project.pbxproj
+++ b/TrackpadAir.xcodeproj/project.pbxproj
@@ -383,7 +383,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 12.6;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -440,7 +440,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 12.6;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
@@ -476,13 +476,13 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 0.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TrackpadAir;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -510,13 +510,13 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 0.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TrackpadAir;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -533,7 +533,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.5;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.me.n.rei.TrackpadAirTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -541,7 +541,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TrackpadAir.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/TrackpadAir";
 				XROS_DEPLOYMENT_TARGET = 2.0;
@@ -561,14 +561,14 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.5;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.me.n.rei.TrackpadAirTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TrackpadAir.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/TrackpadAir";
 				XROS_DEPLOYMENT_TARGET = 2.0;
@@ -612,8 +612,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/NakaokaRei/SwiftAutoGUI";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.22.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/TrackpadAir.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TrackpadAir.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,30 @@
   "originHash" : "10d567ce74adfc210b3b640cc46fbab39e9950679862af024bf1ee7a3730da04",
   "pins" : [
     {
+      "identity" : "opencv-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yeatse/opencv-spm.git",
+      "state" : {
+        "revision" : "151a5374946aa867ff3892e0d69fd85e1ecdaf2e",
+        "version" : "4.13.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
       "identity" : "swiftautogui",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/NakaokaRei/SwiftAutoGUI",
       "state" : {
-        "branch" : "master",
-        "revision" : "b163c53d68d4df0a51771793d580189a06059dcf"
+        "revision" : "51cf8aab581162dde2343bee87ed0854886d9ff1",
+        "version" : "0.22.0"
       }
     }
   ],

--- a/TrackpadAir/Manager/HandPoseManager.swift
+++ b/TrackpadAir/Manager/HandPoseManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Vision
 
+@MainActor
 class HandPoseManager {
     private var handPoseResquest = VNDetectHumanHandPoseRequest()
 
@@ -61,4 +62,3 @@ class HandPoseManager {
         return fingerTips
     }
 }
-

--- a/TrackpadAir/View/HandGesture/HandGestureViewModel.swift
+++ b/TrackpadAir/View/HandGesture/HandGestureViewModel.swift
@@ -50,7 +50,7 @@ class HandGestureViewModel: ObservableObject {
                     height: self.imageHeight
                 )
 
-                self.operate()
+                await self.operate()
             }
         }
     }
@@ -61,7 +61,7 @@ class HandGestureViewModel: ObservableObject {
         event = nil
     }
 
-    func operate() {
+    func operate() async {
         guard let fingerTips else { return }
         let gesture = HandGestureProcessor.process(fingerTips: fingerTips)
         recognizedGesture = gesture
@@ -71,7 +71,7 @@ class HandGestureViewModel: ObservableObject {
             return
         }
 
-        event = actionExecutor.execute(
+        event = await actionExecutor.execute(
             action: action,
             fingerTips: fingerTips,
             previousFingerTips: buffTips
@@ -85,7 +85,7 @@ protocol GestureActionExecuting {
         action: Event,
         fingerTips: FingerTips?,
         previousFingerTips: FingerTips?
-    ) -> Event?
+    ) async -> Event?
 }
 
 struct GestureActionExecutor: GestureActionExecuting {
@@ -93,16 +93,16 @@ struct GestureActionExecutor: GestureActionExecuting {
         action: Event,
         fingerTips: FingerTips?,
         previousFingerTips: FingerTips?
-    ) -> Event? {
+    ) async -> Event? {
         switch action {
         case .moveMouse:
             guard let fingerTips, let previousFingerTips else { return nil }
             let dx = fingerTips.index.x - previousFingerTips.index.x
             let dy = fingerTips.index.y - previousFingerTips.index.y
-            SwiftAutoGUI.moveMouse(dx: dx * 5, dy: dy * 5)
+            await Action.moveMouse(dx: dx * 5, dy: dy * 5).execute()
             return .moveMouse
         case .leftClick:
-            SwiftAutoGUI.leftClick()
+            await Action.leftClick.execute()
             return .leftClick
         case .scroll:
             guard let fingerTips, let previousFingerTips else { return nil }
@@ -110,9 +110,9 @@ struct GestureActionExecutor: GestureActionExecuting {
             let dy = previousFingerTips.index.y - fingerTips.index.y
 
             if abs(dx) >= abs(dy) {
-                SwiftAutoGUI.hscroll(clicks: Int(dx / 3))
+                await Action.hscroll(clicks: Int(dx / 3)).execute()
             } else {
-                SwiftAutoGUI.vscroll(clicks: Int(dy / 3))
+                await Action.vscroll(clicks: Int(dy / 3)).execute()
             }
             return .scroll
         }
@@ -124,33 +124,7 @@ struct PreviewGestureActionExecutor: GestureActionExecuting {
         action: Event,
         fingerTips: FingerTips?,
         previousFingerTips: FingerTips?
-    ) -> Event? {
+    ) async -> Event? {
         action
-    }
-}
-
-extension HandGestureViewModel {
-    func moveMouse() {
-        event = actionExecutor.execute(
-            action: .moveMouse,
-            fingerTips: fingerTips,
-            previousFingerTips: buffTips
-        )
-    }
-
-    func scroll() {
-        event = actionExecutor.execute(
-            action: .scroll,
-            fingerTips: fingerTips,
-            previousFingerTips: buffTips
-        )
-    }
-
-    func leftClick() {
-        event = actionExecutor.execute(
-            action: .leftClick,
-            fingerTips: fingerTips,
-            previousFingerTips: buffTips
-        )
     }
 }

--- a/TrackpadAirTests/TrackpadAirTests.swift
+++ b/TrackpadAirTests/TrackpadAirTests.swift
@@ -93,7 +93,7 @@ struct TrackpadAirTests {
     }
 
     @MainActor
-    @Test func viewModelResolvesConfiguredAction() {
+    @Test func viewModelResolvesConfiguredAction() async {
         let setting = Setting(userDefaults: makeUserDefaults())
         setting.setAction(.leftClick, for: .ringPinch)
         let viewModel = HandGestureViewModel(
@@ -108,7 +108,7 @@ struct TrackpadAirTests {
             little: .init(x: 60, y: 0)
         )
 
-        viewModel.operate()
+        await viewModel.operate()
 
         #expect(viewModel.recognizedGesture == .ringPinch)
         #expect(viewModel.event == .leftClick)
@@ -127,7 +127,7 @@ private struct FakeGestureActionExecutor: GestureActionExecuting {
         action: Event,
         fingerTips: FingerTips?,
         previousFingerTips: FingerTips?
-    ) -> Event? {
+    ) async -> Event? {
         action
     }
 }


### PR DESCRIPTION
## Summary
- update SwiftAutoGUI using an Up to Next Major requirement from `0.22.0` (`0.22.0 ..< 1.0.0`)
- migrate gesture execution to SwiftAutoGUI’s async `Action` API
- adopt Swift 6 concurrency requirements and macOS 26 deployment target
- update tests and documentation for the new API and platform requirements

## Verification
- Swift package resolution succeeds with SwiftAutoGUI `0.22.0`
- full macOS `xcodebuild test` succeeds