### PR TITLE
Fix code signing in release tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,8 @@ jobs:
           xcodebuild test \
             -project TrackpadAir.xcodeproj \
             -scheme TrackpadAir \
-            -destination 'platform=macOS'
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO
 
       - name: Archive app
         run: |

--- a/TrackpadAir.xcodeproj/project.pbxproj
+++ b/TrackpadAir.xcodeproj/project.pbxproj
@@ -477,7 +477,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 0.1.3;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TrackpadAir;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -511,7 +511,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 0.1.3;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TrackpadAir;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary
- disable code signing for the test step in the release workflow
- keep Developer ID signing enabled for the archive step

The imported certificate is a `Developer ID Application` certificate, while the test target otherwise requests a `Mac Development` certificate.

## Verification
- `xcodebuild test -project TrackpadAir.xcodeproj -scheme TrackpadAir -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`