### PR TITLE
Add custom gesture command builder

### DIFF
--- a/TrackpadAir/Model/Event.swift
+++ b/TrackpadAir/Model/Event.swift
@@ -7,45 +7,107 @@
 
 import Foundation
 
-enum Event: String, CaseIterable, Identifiable {
-    case moveMouse = "move_mouse"
-    case leftClick = "left_click"
-    case scroll = "scroll"
-
-    var id: String {
-        rawValue
+struct Event: Codable, Hashable, Identifiable {
+    enum Behavior: String, Codable {
+        case moveMouse
+        case scroll
+        case sequence
     }
 
-    var displayName: String {
-        switch self {
-        case .moveMouse:
-            return "Move Mouse"
-        case .leftClick:
-            return "Left Click"
-        case .scroll:
-            return "Scroll"
-        }
-    }
-
-    var symbolName: String {
-        switch self {
-        case .moveMouse:
-            return "cursorarrow.motionlines"
-        case .leftClick:
-            return "cursorarrow.click"
-        case .scroll:
-            return "arrow.up.and.down"
-        }
-    }
+    var id: String
+    var displayName: String
+    var symbolName: String
+    var behavior: Behavior
+    var steps: [CommandStep]
 
     var description: String {
-        switch self {
+        switch behavior {
         case .moveMouse:
             return "Move the pointer using the index finger delta."
-        case .leftClick:
-            return "Perform a left mouse click."
         case .scroll:
             return "Scroll vertically or horizontally from finger movement."
+        case .sequence:
+            if steps.isEmpty {
+                return "No actions"
+            }
+            return steps.map(\.summary).joined(separator: "  →  ")
+        }
+    }
+
+    static let moveMouse = Event(
+        id: "move_mouse",
+        displayName: "Move Mouse",
+        symbolName: "cursorarrow.motionlines",
+        behavior: .moveMouse,
+        steps: []
+    )
+
+    static let leftClick = Event(
+        id: "left_click",
+        displayName: "Left Click",
+        symbolName: "cursorarrow.click",
+        behavior: .sequence,
+        steps: [.init(kind: .leftClick)]
+    )
+
+    static let scroll = Event(
+        id: "scroll",
+        displayName: "Scroll",
+        symbolName: "arrow.up.and.down",
+        behavior: .scroll,
+        steps: []
+    )
+
+    static let builtIns = [moveMouse, leftClick, scroll]
+
+    static func newCommand() -> Event {
+        Event(
+            id: UUID().uuidString,
+            displayName: "New Command",
+            symbolName: "command",
+            behavior: .sequence,
+            steps: [.init(kind: .leftClick)]
+        )
+    }
+}
+
+struct CommandStep: Codable, Hashable, Identifiable {
+    enum Kind: String, Codable, CaseIterable, Identifiable {
+        case leftClick
+        case rightClick
+        case doubleClick
+        case typeText
+        case shortcut
+        case wait
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .leftClick: return "Left Click"
+            case .rightClick: return "Right Click"
+            case .doubleClick: return "Double Click"
+            case .typeText: return "Type Text"
+            case .shortcut: return "Keyboard Shortcut"
+            case .wait: return "Wait"
+            }
+        }
+    }
+
+    var id = UUID()
+    var kind: Kind
+    var value = ""
+
+    var summary: String {
+        switch kind {
+        case .leftClick, .rightClick, .doubleClick:
+            return kind.displayName
+        case .typeText:
+            return value.isEmpty ? "Type Text" : "Type “\(value)”"
+        case .shortcut:
+            return value.isEmpty ? "Keyboard Shortcut" : value
+        case .wait:
+            return "Wait \(Double(value) ?? 0) sec"
         }
     }
 }

--- a/TrackpadAir/View/HandGesture/HandGestureViewModel.swift
+++ b/TrackpadAir/View/HandGesture/HandGestureViewModel.swift
@@ -64,9 +64,15 @@ class HandGestureViewModel: ObservableObject {
     func operate() async {
         guard let fingerTips else { return }
         let gesture = HandGestureProcessor.process(fingerTips: fingerTips)
+        let previousGesture = recognizedGesture
         recognizedGesture = gesture
 
         guard let action = setting.action(for: gesture) else {
+            event = nil
+            return
+        }
+
+        if action.behavior == .sequence, gesture == previousGesture {
             event = nil
             return
         }
@@ -94,16 +100,13 @@ struct GestureActionExecutor: GestureActionExecuting {
         fingerTips: FingerTips?,
         previousFingerTips: FingerTips?
     ) async -> Event? {
-        switch action {
+        switch action.behavior {
         case .moveMouse:
             guard let fingerTips, let previousFingerTips else { return nil }
             let dx = fingerTips.index.x - previousFingerTips.index.x
             let dy = fingerTips.index.y - previousFingerTips.index.y
             await Action.moveMouse(dx: dx * 5, dy: dy * 5).execute()
-            return .moveMouse
-        case .leftClick:
-            await Action.leftClick.execute()
-            return .leftClick
+            return action
         case .scroll:
             guard let fingerTips, let previousFingerTips else { return nil }
             let dx = previousFingerTips.index.x - fingerTips.index.x
@@ -114,7 +117,56 @@ struct GestureActionExecutor: GestureActionExecuting {
             } else {
                 await Action.vscroll(clicks: Int(dy / 3)).execute()
             }
-            return .scroll
+            return action
+        case .sequence:
+            await action.steps.compactMap(\.swiftAutoGUIAction).execute()
+            return action
+        }
+    }
+}
+
+private extension CommandStep {
+    var swiftAutoGUIAction: Action? {
+        switch kind {
+        case .leftClick:
+            return .leftClick
+        case .rightClick:
+            return .rightClick
+        case .doubleClick:
+            return .doubleClick()
+        case .typeText:
+            return .write(value)
+        case .shortcut:
+            let keys = value
+                .split(separator: "+")
+                .compactMap { Key(commandName: String($0)) }
+            return keys.isEmpty ? nil : .keyShortcut(keys)
+        case .wait:
+            return .wait(max(0, Double(value) ?? 0))
+        }
+    }
+}
+
+private extension Key {
+    init?(commandName: String) {
+        let name = commandName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let aliases: [String: Key] = [
+            "cmd": .command, "⌘": .command,
+            "ctrl": .control, "⌃": .control,
+            "alt": .option, "opt": .option, "⌥": .option,
+            "⇧": .shift,
+            "return": .returnKey, "enter": .returnKey,
+            "esc": .escape,
+            "left": .leftArrow, "right": .rightArrow,
+            "up": .upArrow, "down": .downArrow,
+            "0": .zero, "1": .one, "2": .two, "3": .three, "4": .four,
+            "5": .five, "6": .six, "7": .seven, "8": .eight, "9": .nine
+        ]
+
+        if let key = aliases[name] {
+            self = key
+        } else {
+            self.init(rawValue: name)
         }
     }
 }

--- a/TrackpadAir/View/Settings/Setting.swift
+++ b/TrackpadAir/View/Settings/Setting.swift
@@ -12,76 +12,130 @@ import Combine
 class Setting: ObservableObject {
     static let shared = Setting()
 
-    private static let storageKey = "gestureActionAssignments"
+    private static let assignmentStorageKey = "gestureActionAssignments"
+    private static let commandStorageKey = "customGestureCommands"
     private static let noneValue = "__none__"
 
     private let userDefaults: UserDefaults
 
-    @Published private(set) var assignments: [HandGestureState: Event?] {
-        didSet {
-            saveAssignments()
-        }
+    @Published private(set) var assignments: [HandGestureState: String] {
+        didSet { saveAssignments() }
+    }
+
+    @Published private(set) var customCommands: [Event] {
+        didSet { saveCommands() }
+    }
+
+    var availableCommands: [Event] {
+        Event.builtIns + customCommands
     }
 
     init(userDefaults: UserDefaults = .standard) {
+        let loadedCommands = Self.loadCommands(userDefaults: userDefaults)
         self.userDefaults = userDefaults
-        self.assignments = Self.loadAssignments(userDefaults: userDefaults)
+        self.customCommands = loadedCommands
+        self.assignments = Self.loadAssignments(
+            userDefaults: userDefaults,
+            validCommandIDs: Set(Event.builtIns.map(\.id) + loadedCommands.map(\.id))
+        )
     }
 
-    static var defaultAssignments: [HandGestureState: Event?] {
+    static var defaultAssignments: [HandGestureState: String] {
         var assignments = Dictionary(
-            uniqueKeysWithValues: HandGestureState.assignableGestures.map { ($0, Optional<Event>.none) }
+            uniqueKeysWithValues: HandGestureState.assignableGestures.map { ($0, noneValue) }
         )
-        assignments[.indexPinch] = .moveMouse
-        assignments[.middlePinch] = .leftClick
-        assignments[.indexMiddlePinch] = .scroll
+        assignments[.indexPinch] = Event.moveMouse.id
+        assignments[.middlePinch] = Event.leftClick.id
+        assignments[.indexMiddlePinch] = Event.scroll.id
         return assignments
     }
 
     func action(for gesture: HandGestureState) -> Event? {
-        guard gesture != .none else { return nil }
-        return assignments[gesture] ?? nil
+        guard gesture != .none,
+              let commandID = assignments[gesture],
+              commandID != Self.noneValue else {
+            return nil
+        }
+        return availableCommands.first { $0.id == commandID }
     }
 
     func setAction(_ action: Event?, for gesture: HandGestureState) {
         guard HandGestureState.assignableGestures.contains(gesture) else { return }
-        assignments[gesture] = action
+        assignments[gesture] = action?.id ?? Self.noneValue
+    }
+
+    func addCommand() -> Event {
+        let command = Event.newCommand()
+        customCommands.append(command)
+        return command
+    }
+
+    func updateCommand(_ command: Event) {
+        if let index = customCommands.firstIndex(where: { $0.id == command.id }) {
+            customCommands[index] = command
+        } else {
+            customCommands.append(command)
+        }
+    }
+
+    func deleteCommands(at offsets: IndexSet) {
+        let deletedIDs = Set(offsets.map { customCommands[$0].id })
+        for index in offsets.sorted(by: >) {
+            customCommands.remove(at: index)
+        }
+
+        for gesture in HandGestureState.assignableGestures {
+            guard let commandID = assignments[gesture],
+                  deletedIDs.contains(commandID) else {
+                continue
+            }
+            assignments[gesture] = Self.noneValue
+        }
     }
 
     func resetToDefaults() {
         assignments = Self.defaultAssignments
     }
 
-    private static func loadAssignments(userDefaults: UserDefaults) -> [HandGestureState: Event?] {
-        guard let storedAssignments = userDefaults.dictionary(forKey: storageKey) as? [String: String] else {
+    private static func loadCommands(userDefaults: UserDefaults) -> [Event] {
+        guard let data = userDefaults.data(forKey: commandStorageKey),
+              let commands = try? JSONDecoder().decode([Event].self, from: data) else {
+            return []
+        }
+        return commands.filter { $0.behavior == .sequence }
+    }
+
+    private static func loadAssignments(
+        userDefaults: UserDefaults,
+        validCommandIDs: Set<String>
+    ) -> [HandGestureState: String] {
+        guard let storedAssignments = userDefaults.dictionary(forKey: assignmentStorageKey) as? [String: String] else {
             return defaultAssignments
         }
 
         var assignments = defaultAssignments
-
-        for (gestureID, eventID) in storedAssignments {
+        for (gestureID, commandID) in storedAssignments {
             guard let gesture = HandGestureState(rawValue: gestureID),
-                  HandGestureState.assignableGestures.contains(gesture) else {
+                  HandGestureState.assignableGestures.contains(gesture),
+                  commandID == noneValue || validCommandIDs.contains(commandID) else {
                 continue
             }
-
-            if eventID == noneValue {
-                assignments[gesture] = nil
-            } else if let event = Event(rawValue: eventID) {
-                assignments[gesture] = event
-            }
+            assignments[gesture] = commandID
         }
-
         return assignments
     }
 
     private func saveAssignments() {
         let storedAssignments = assignments.reduce(into: [String: String]()) { result, item in
-            let (gesture, action) = item
+            let (gesture, commandID) = item
             guard HandGestureState.assignableGestures.contains(gesture) else { return }
-            result[gesture.rawValue] = action?.rawValue ?? Self.noneValue
+            result[gesture.rawValue] = commandID
         }
+        userDefaults.set(storedAssignments, forKey: Self.assignmentStorageKey)
+    }
 
-        userDefaults.set(storedAssignments, forKey: Self.storageKey)
+    private func saveCommands() {
+        guard let data = try? JSONEncoder().encode(customCommands) else { return }
+        userDefaults.set(data, forKey: Self.commandStorageKey)
     }
 }

--- a/TrackpadAir/View/Settings/SettingsView.swift
+++ b/TrackpadAir/View/Settings/SettingsView.swift
@@ -9,63 +9,127 @@ import SwiftUI
 
 struct SettingsView: View {
     @StateObject private var setting = Setting.shared
+    @State private var editingCommand: Event?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            header
-            Divider()
-            gestureAssignments
-            Divider()
-            footer
+        TabView {
+            assignmentsView
+                .tabItem { Label("Assignments", systemImage: "hand.pinch") }
+            commandsView
+                .tabItem { Label("Commands", systemImage: "command") }
         }
-        .padding(24)
-        .frame(width: 620, height: 520)
-    }
-
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Gesture Actions")
-                .font(.title2)
-                .fontWeight(.semibold)
-            Text("Assign an action to each recognized pinch gesture.")
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    private var gestureAssignments: some View {
-        ScrollView {
-            VStack(spacing: 0) {
-                ForEach(HandGestureState.assignableGestures) { gesture in
-                    GestureAssignmentRow(
-                        gesture: gesture,
-                        selectedActionID: binding(for: gesture)
-                    )
-
-                    if gesture != HandGestureState.assignableGestures.last {
-                        Divider()
-                            .padding(.leading, 40)
-                    }
-                }
+        .padding(20)
+        .frame(width: 700, height: 590)
+        .sheet(item: $editingCommand) { command in
+            CommandEditor(command: command) {
+                setting.updateCommand($0)
             }
         }
     }
 
-    private var footer: some View {
-        HStack {
-            Text("Changes are saved automatically.")
-                .foregroundStyle(.secondary)
-            Spacer()
-            Button("Restore Defaults") {
-                setting.resetToDefaults()
+    private var assignmentsView: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            SettingsHeader(
+                title: "Gesture Actions",
+                subtitle: "Assign a built-in action or one of your commands to each gesture."
+            )
+            Divider()
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(HandGestureState.assignableGestures) { gesture in
+                        GestureAssignmentRow(
+                            gesture: gesture,
+                            commands: setting.availableCommands,
+                            selectedActionID: binding(for: gesture)
+                        )
+                        if gesture != HandGestureState.assignableGestures.last {
+                            Divider().padding(.leading, 40)
+                        }
+                    }
+                }
+            }
+            Divider()
+            HStack {
+                Text("Changes are saved automatically.")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Restore Defaults") { setting.resetToDefaults() }
+            }
+        }
+    }
+
+    private var commandsView: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                SettingsHeader(
+                    title: "Command Builder",
+                    subtitle: "Combine actions in order, then assign the command to a gesture."
+                )
+                Spacer()
+                Button {
+                    editingCommand = Event.newCommand()
+                } label: {
+                    Label("New Command", systemImage: "plus")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            Divider()
+
+            if setting.customCommands.isEmpty {
+                ContentUnavailableView(
+                    "No Commands",
+                    systemImage: "command",
+                    description: Text("Create a command by combining clicks, text, shortcuts, and waits.")
+                )
+            } else {
+                List {
+                    ForEach(setting.customCommands) { command in
+                        Button {
+                            editingCommand = command
+                        } label: {
+                            HStack(spacing: 12) {
+                                Image(systemName: command.symbolName)
+                                    .frame(width: 24)
+                                    .foregroundStyle(.secondary)
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text(command.displayName)
+                                        .fontWeight(.medium)
+                                    Text(command.description)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .foregroundStyle(.tertiary)
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .onDelete(perform: setting.deleteCommands)
+                }
             }
         }
     }
 
     private func binding(for gesture: HandGestureState) -> Binding<String> {
         Binding {
-            setting.action(for: gesture)?.rawValue ?? GestureAssignmentRow.noneActionID
+            setting.action(for: gesture)?.id ?? GestureAssignmentRow.noneActionID
         } set: { actionID in
-            setting.setAction(Event(rawValue: actionID), for: gesture)
+            setting.setAction(setting.availableCommands.first { $0.id == actionID }, for: gesture)
+        }
+    }
+}
+
+private struct SettingsHeader: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(.title2).fontWeight(.semibold)
+            Text(subtitle).foregroundStyle(.secondary)
         }
     }
 }
@@ -74,6 +138,7 @@ private struct GestureAssignmentRow: View {
     static let noneActionID = "none"
 
     let gesture: HandGestureState
+    let commands: [Event]
     let selectedActionID: Binding<String>
 
     var body: some View {
@@ -82,29 +147,110 @@ private struct GestureAssignmentRow: View {
                 .font(.title3)
                 .frame(width: 26)
                 .foregroundStyle(.secondary)
-
             VStack(alignment: .leading, spacing: 3) {
-                Text(gesture.displayName)
-                    .font(.body)
-                    .fontWeight(.medium)
-                Text(gesture.description)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                Text(gesture.displayName).fontWeight(.medium)
+                Text(gesture.description).font(.caption).foregroundStyle(.secondary)
             }
-
             Spacer(minLength: 24)
-
             Picker("Action", selection: selectedActionID) {
                 Text("None").tag(Self.noneActionID)
-                ForEach(Event.allCases) { event in
-                    Label(event.displayName, systemImage: event.symbolName)
-                        .tag(event.rawValue)
+                Section("Built-in") {
+                    ForEach(Event.builtIns) { command in
+                        Label(command.displayName, systemImage: command.symbolName).tag(command.id)
+                    }
+                }
+                if commands.count > Event.builtIns.count {
+                    Section("My Commands") {
+                        ForEach(commands.filter { command in
+                            !Event.builtIns.contains { $0.id == command.id }
+                        }) { command in
+                            Label(command.displayName, systemImage: command.symbolName).tag(command.id)
+                        }
+                    }
                 }
             }
             .labelsHidden()
-            .frame(width: 180)
+            .frame(width: 210)
         }
         .padding(.vertical, 12)
         .padding(.horizontal, 2)
+    }
+}
+
+private struct CommandEditor: View {
+    @Environment(\.dismiss) private var dismiss
+    @State var command: Event
+    let onSave: (Event) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Edit Command").font(.title2).fontWeight(.semibold)
+            TextField("Command name", text: $command.displayName)
+            Divider()
+
+            List {
+                ForEach($command.steps) { $step in
+                    CommandStepRow(step: $step)
+                }
+                .onDelete { command.steps.remove(atOffsets: $0) }
+                .onMove { command.steps.move(fromOffsets: $0, toOffset: $1) }
+            }
+            .frame(minHeight: 280)
+
+            HStack {
+                Menu {
+                    ForEach(CommandStep.Kind.allCases) { kind in
+                        Button(kind.displayName) {
+                            command.steps.append(CommandStep(kind: kind))
+                        }
+                    }
+                } label: {
+                    Label("Add Action", systemImage: "plus")
+                }
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Save") {
+                    command.displayName = command.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if command.displayName.isEmpty { command.displayName = "Untitled Command" }
+                    onSave(command)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(24)
+        .frame(width: 620, height: 470)
+    }
+}
+
+private struct CommandStepRow: View {
+    @Binding var step: CommandStep
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "line.3.horizontal")
+                .foregroundStyle(.tertiary)
+            Picker("Action", selection: $step.kind) {
+                ForEach(CommandStep.Kind.allCases) { kind in
+                    Text(kind.displayName).tag(kind)
+                }
+            }
+            .frame(width: 170)
+
+            switch step.kind {
+            case .typeText:
+                TextField("Text to type", text: $step.value)
+            case .shortcut:
+                TextField("command+shift+p", text: $step.value)
+            case .wait:
+                TextField("Seconds", text: $step.value)
+                    .frame(width: 100)
+                Text("seconds").foregroundStyle(.secondary)
+            case .leftClick, .rightClick, .doubleClick:
+                Text(step.kind.displayName).foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 4)
     }
 }

--- a/TrackpadAirTests/TrackpadAirTests.swift
+++ b/TrackpadAirTests/TrackpadAirTests.swift
@@ -80,8 +80,8 @@ struct TrackpadAirTests {
         userDefaults.set(
             [
                 "indexPinch": "not_an_event",
-                "not_a_gesture": Event.scroll.rawValue,
-                "ringPinch": Event.leftClick.rawValue
+                "not_a_gesture": Event.scroll.id,
+                "ringPinch": Event.leftClick.id
             ],
             forKey: "gestureActionAssignments"
         )
@@ -90,6 +90,36 @@ struct TrackpadAirTests {
 
         #expect(setting.action(for: .indexPinch) == .moveMouse)
         #expect(setting.action(for: .ringPinch) == .leftClick)
+    }
+
+    @MainActor
+    @Test func customCommandsPersistAndCanBeAssigned() {
+        let userDefaults = makeUserDefaults()
+        let setting = Setting(userDefaults: userDefaults)
+        var command = setting.addCommand()
+        command.displayName = "Open Search"
+        command.steps = [
+            CommandStep(kind: .shortcut, value: "command+space"),
+            CommandStep(kind: .typeText, value: "TrackpadAir")
+        ]
+        setting.updateCommand(command)
+        setting.setAction(command, for: .threeFingerPinch)
+
+        let restoredSetting = Setting(userDefaults: userDefaults)
+
+        #expect(restoredSetting.customCommands == [command])
+        #expect(restoredSetting.action(for: .threeFingerPinch) == command)
+    }
+
+    @MainActor
+    @Test func deletingCommandClearsItsAssignments() {
+        let setting = Setting(userDefaults: makeUserDefaults())
+        let command = setting.addCommand()
+        setting.setAction(command, for: .ringPinch)
+
+        setting.deleteCommands(at: IndexSet(integer: 0))
+
+        #expect(setting.action(for: .ringPinch) == nil)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- add a command builder for composing clicks, text input, keyboard shortcuts, and waits
- allow custom commands to be assigned to recognized hand gestures
- persist commands and assignments while retaining built-in mouse movement and scrolling
- execute sequence commands once when a gesture begins to prevent repeated input

## Test plan
- `xcodebuild test -project TrackpadAir.xcodeproj -scheme TrackpadAir -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`